### PR TITLE
Update actions/upload-artifact to v4 as v3 is deprecated and causes failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
         ./contrast sarif ${{ steps.required-args.outputs.args }} ${{ steps.optional-args.outputs.args }} 
         echo sarif=$(cat contrast.sarif) >> $GITHUB_OUTPUT
     - name: Upload sarif file to summary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: contrast.sarif
         path: contrast.sarif


### PR DESCRIPTION
`actions/upload-artifact@v3` was deprecated on November 30, 2024 and no longer works on github.com and therefore attempting to use this action fails with a vague message:
> Error: Missing download info for actions/upload-artifact@v3

Since v3 is still the only option available for GitHub Enterprise Server users, this should be released as a new major version of this action IMO.